### PR TITLE
[Test/#5] member controller 슬라이스 테스트 작성, Spring Rest Docs 설정, treansactional 선언

### DIFF
--- a/.github/workflows/githubaction-ci.yml
+++ b/.github/workflows/githubaction-ci.yml
@@ -30,15 +30,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew clean build -x test
-
       - name: Check Code Formatting
         run: ./gradlew spotlessJavaCheck
 
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test asciidoctor
+
       - name: Test with Gradle
         run: |
-          TEST_RESULT=$(./gradlew test)
+          TEST_RESULT=$(./gradlew test -x asciidoctor)
           if [[ $TEST_RESULT == *"FAILURE"* ]]; then
             echo "::error::Unit tests failed. Please check the code and try again."
             exit 1

--- a/.github/workflows/githubaction-ci.yml
+++ b/.github/workflows/githubaction-ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew spotlessJavaCheck
 
       - name: Build with Gradle
-        run: ./gradlew clean build -x test asciidoctor
+        run: ./gradlew clean build -x test -x asciidoctor
 
       - name: Test with Gradle
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,12 @@ test {
 
 asciidoctor {
 	inputs.dir snippetsDir
-	configurations 'asciidoctorExt'
+	configurations 'asciidoctorExtensions'
 	dependsOn test
 }
 
 configurations {
-	asciidoctorExt
+	asciidoctorExtensions
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -68,7 +68,7 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'com.h2database:h2'
-	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 spotless {
@@ -92,6 +92,11 @@ subprojects {
 	jar {
 		enabled = true
 	}
+
+	java {
+		sourceCompatibility = '11'
+	}
+
 
 	repositories {
 		mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,36 @@ plugins {
 	id 'org.springframework.boot' version '2.7.14-SNAPSHOT'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'com.diffplug.spotless' version '6.11.0'
+	id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 java {
 	sourceCompatibility = '11'
 }
 
+bootJar {
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}/html5") {
+		into 'static/docs'
+	}
+}
+
+ext {
+	snippetsDir = file('build/generated-snippets')
+}
+
+test {
+	outputs.dir snippetsDir
+}
+
+asciidoctor {
+	inputs.dir snippetsDir
+	configurations 'asciidoctorExt'
+	dependsOn test
+}
+
 configurations {
+	asciidoctorExt
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -41,8 +64,11 @@ dependencies {
 	implementation project(':wronganswernote-module:wronganswernote-persistence-adapter')
 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'com.h2database:h2'
+	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.h2database:h2'
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 spotless {

--- a/member-module/member-application/build.gradle
+++ b/member-module/member-application/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     implementation project(':core-module')
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/member-module/member-application/src/main/java/com/ohdab/JoinService.java
+++ b/member-module/member-application/src/main/java/com/ohdab/JoinService.java
@@ -14,9 +14,11 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class JoinService implements JoinUsecase {
 
     private final PasswordEncoder passwordEncoder;

--- a/member-module/member-application/src/main/java/com/ohdab/LoginService.java
+++ b/member-module/member-application/src/main/java/com/ohdab/LoginService.java
@@ -14,9 +14,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
+@Transactional(readOnly = true)
 public class LoginService implements LoginUsecase {
 
     private final MemberHelperService memberHelperService;
@@ -24,6 +26,7 @@ public class LoginService implements LoginUsecase {
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
 
+    @Override
     public LoginResDto login(LoginReqDto loginReqDto) {
         UserDetails userDetails = userDetailsService.loadUserByUsername(loginReqDto.getName());
         Member member = memberHelperService.findExistingMember(loginReqDto.getName());

--- a/member-module/member-persistence-adapter/src/main/java/com/ohdab/mapper/MemberPersistenceMapper.java
+++ b/member-module/member-persistence-adapter/src/main/java/com/ohdab/mapper/MemberPersistenceMapper.java
@@ -7,7 +7,10 @@ import com.ohdab.entity.AuthorityJpa;
 import com.ohdab.entity.MemberJpa;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberPersistenceMapper {
 
     public static Member toDomain(MemberJpa memberJpa) {

--- a/member-module/member-web-adapter/out/test/resources/application.yml
+++ b/member-module/member-web-adapter/out/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true

--- a/member-module/member-web-adapter/src/main/java/com/ohdab/MemberController.java
+++ b/member-module/member-web-adapter/src/main/java/com/ohdab/MemberController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user")
+@RequestMapping("/members")
 public class MemberController {
 
     private final JoinUsecase joinUsecase;
@@ -23,13 +23,13 @@ public class MemberController {
     @PostMapping("/join")
     public ResponseEntity<JoinRes> join(@RequestBody JoinReq joinReq) {
         joinUsecase.join(MemberWebMapper.toJoinReqDto(joinReq));
-        return ResponseEntity.ok(JoinRes.builder().message("회원가입이 완료되었습니다.").build());
+        return ResponseEntity.ok(MemberWebMapper.toJoinRes());
     }
 
     @PostMapping("/login")
     public ResponseEntity<LoginRes> login(@RequestBody LoginReq loginReq) {
         LoginResDto loginResDto = loginUsecase.login(MemberWebMapper.toLoginReqDto(loginReq));
-        return ResponseEntity.ok(MemberWebMapper.toLoginResDto(loginResDto));
+        return ResponseEntity.ok(MemberWebMapper.toLoginRes(loginResDto));
     }
 
     @GetMapping("/test")

--- a/member-module/member-web-adapter/src/main/java/com/ohdab/MemberController.java
+++ b/member-module/member-web-adapter/src/main/java/com/ohdab/MemberController.java
@@ -8,6 +8,7 @@ import com.ohdab.request.JoinReq;
 import com.ohdab.request.LoginReq;
 import com.ohdab.response.JoinRes;
 import com.ohdab.response.LoginRes;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,13 +22,13 @@ public class MemberController {
     private final LoginUsecase loginUsecase;
 
     @PostMapping("/join")
-    public ResponseEntity<JoinRes> join(@RequestBody JoinReq joinReq) {
+    public ResponseEntity<JoinRes> join(@Valid @RequestBody JoinReq joinReq) {
         joinUsecase.join(MemberWebMapper.toJoinReqDto(joinReq));
         return ResponseEntity.ok(MemberWebMapper.toJoinRes());
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginRes> login(@RequestBody LoginReq loginReq) {
+    public ResponseEntity<LoginRes> login(@Valid @RequestBody LoginReq loginReq) {
         LoginResDto loginResDto = loginUsecase.login(MemberWebMapper.toLoginReqDto(loginReq));
         return ResponseEntity.ok(MemberWebMapper.toLoginRes(loginResDto));
     }

--- a/member-module/member-web-adapter/src/main/java/com/ohdab/mapper/MemberWebMapper.java
+++ b/member-module/member-web-adapter/src/main/java/com/ohdab/mapper/MemberWebMapper.java
@@ -5,6 +5,7 @@ import com.ohdab.dto.LoginReqDto;
 import com.ohdab.dto.LoginResDto;
 import com.ohdab.request.JoinReq;
 import com.ohdab.request.LoginReq;
+import com.ohdab.response.JoinRes;
 import com.ohdab.response.LoginRes;
 
 public class MemberWebMapper {
@@ -24,11 +25,15 @@ public class MemberWebMapper {
                 .build();
     }
 
-    public static LoginRes toLoginResDto(LoginResDto loginResDto) {
+    public static LoginRes toLoginRes(LoginResDto loginResDto) {
         return LoginRes.builder()
                 .message("로그인에 성공하였습니다.")
                 .memberId(loginResDto.getMemberId())
                 .jwtToken(loginResDto.getJwtToken())
                 .build();
+    }
+
+    public static JoinRes toJoinRes() {
+        return JoinRes.builder().message("회원가입이 완료되었습니다.").build();
     }
 }

--- a/member-module/member-web-adapter/src/main/java/com/ohdab/mapper/MemberWebMapper.java
+++ b/member-module/member-web-adapter/src/main/java/com/ohdab/mapper/MemberWebMapper.java
@@ -7,7 +7,10 @@ import com.ohdab.request.JoinReq;
 import com.ohdab.request.LoginReq;
 import com.ohdab.response.JoinRes;
 import com.ohdab.response.LoginRes;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberWebMapper {
 
     public static JoinReqDto toJoinReqDto(JoinReq joinReq) {

--- a/src/docs/asciidoc/ohdab.adoc
+++ b/src/docs/asciidoc/ohdab.adoc
@@ -1,0 +1,28 @@
+= Ohdab API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+== Member
+
+=== 회원가입
+
+==== Request
+
+include::{snippets}/members/join/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/members/join/http-response.adoc[]
+
+=== 로그인
+
+==== Request
+
+include::{snippets}/members/login/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/members/login/http-response.adoc[]

--- a/src/test/java/com/ohdab/webmvc/member/MemberControllerTest.java
+++ b/src/test/java/com/ohdab/webmvc/member/MemberControllerTest.java
@@ -1,14 +1,5 @@
 package com.ohdab.webmvc.member;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ohdab.MemberController;
 import com.ohdab.dto.LoginResDto;
@@ -18,7 +9,6 @@ import com.ohdab.request.JoinReq;
 import com.ohdab.request.LoginReq;
 import com.ohdab.response.JoinRes;
 import com.ohdab.response.LoginRes;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -30,8 +20,19 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 @AutoConfigureRestDocs
-@WebMvcTest(MemberController.class)
+@WebMvcTest(controllers = MemberController.class)
 class MemberControllerTest {
 
     @Autowired private MockMvc mockMvc;

--- a/src/test/java/com/ohdab/webmvc/member/MemberControllerTest.java
+++ b/src/test/java/com/ohdab/webmvc/member/MemberControllerTest.java
@@ -1,0 +1,113 @@
+package com.ohdab.webmvc.member;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ohdab.MemberController;
+import com.ohdab.dto.LoginResDto;
+import com.ohdab.port.in.JoinUsecase;
+import com.ohdab.port.in.LoginUsecase;
+import com.ohdab.request.JoinReq;
+import com.ohdab.request.LoginReq;
+import com.ohdab.response.JoinRes;
+import com.ohdab.response.LoginRes;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@AutoConfigureRestDocs
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private JoinUsecase joinUsecase;
+
+    @MockBean private LoginUsecase loginUsecase;
+
+    @Test
+    @WithMockUser
+    void 회원가입() throws Exception {
+        // given
+        final String JOIN_URL = "/members/join";
+        final JoinReq joinReq =
+                JoinReq.builder().name("홍길동").password("1234").role(List.of("STUDENT")).build();
+        final JoinRes joinRes = JoinRes.builder().message("회원가입이 완료되었습니다.").build();
+
+        // when
+        ResultActions resultActions =
+                mockMvc.perform(
+                        post(JOIN_URL)
+                                .with(csrf())
+                                .content(objectMapper.writeValueAsString(joinReq))
+                                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("$.message").value(joinRes.getMessage()))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(createDocument("members/join"));
+    }
+
+    @Test
+    @WithMockUser
+    void 로그인() throws Exception {
+        // given
+        final String LOGIN_URL = "/members/login";
+        final LoginReq loginReq = LoginReq.builder().name("홍길동").password("1234").build();
+        final LoginRes loginRes =
+                LoginRes.builder()
+                        .memberId(1L)
+                        .message("로그인에 성공하였습니다.")
+                        .jwtToken("jwt-token")
+                        .build();
+        final LoginResDto loginResDto =
+                LoginResDto.builder().memberId(1L).jwtToken("jwt-token").build();
+
+        // when
+        when(loginUsecase.login(any())).thenReturn(loginResDto);
+        ResultActions resultActions =
+                mockMvc.perform(
+                                post(LOGIN_URL)
+                                        .with(csrf())
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(loginReq)))
+                        .andDo(print());
+
+        // then
+        resultActions
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("$.message").value(loginRes.getMessage()),
+                        jsonPath("$.memberId").value(loginRes.getMemberId()),
+                        jsonPath("$.jwtToken").value(loginRes.getJwtToken()))
+                .andDo(print())
+                .andDo(createDocument("members/login"));
+    }
+
+    private RestDocumentationResultHandler createDocument(String identifier) {
+        return document(
+                identifier, preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint()));
+    }
+}

--- a/src/test/java/com/ohdab/webmvc/member/MemberControllerTest.java
+++ b/src/test/java/com/ohdab/webmvc/member/MemberControllerTest.java
@@ -1,5 +1,14 @@
 package com.ohdab.webmvc.member;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ohdab.MemberController;
 import com.ohdab.dto.LoginResDto;
@@ -9,6 +18,7 @@ import com.ohdab.request.JoinReq;
 import com.ohdab.request.LoginReq;
 import com.ohdab.response.JoinRes;
 import com.ohdab.response.LoginRes;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -18,18 +28,6 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @AutoConfigureRestDocs
 @WebMvcTest(controllers = MemberController.class)
@@ -52,20 +50,17 @@ class MemberControllerTest {
         final JoinRes joinRes = JoinRes.builder().message("회원가입이 완료되었습니다.").build();
 
         // when
-        ResultActions resultActions =
-                mockMvc.perform(
+
+        // then
+        mockMvc.perform(
                         post(JOIN_URL)
                                 .with(csrf())
                                 .content(objectMapper.writeValueAsString(joinReq))
-                                .contentType(MediaType.APPLICATION_JSON));
-
-        // then
-        resultActions
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andExpectAll(
                         status().isOk(),
                         content().contentType(MediaType.APPLICATION_JSON),
                         jsonPath("$.message").value(joinRes.getMessage()))
-                .andExpect(status().isOk())
                 .andDo(print())
                 .andDo(createDocument("members/join"));
     }
@@ -87,16 +82,13 @@ class MemberControllerTest {
 
         // when
         when(loginUsecase.login(any())).thenReturn(loginResDto);
-        ResultActions resultActions =
-                mockMvc.perform(
-                                post(LOGIN_URL)
-                                        .with(csrf())
-                                        .contentType(MediaType.APPLICATION_JSON)
-                                        .content(objectMapper.writeValueAsString(loginReq)))
-                        .andDo(print());
 
         // then
-        resultActions
+        mockMvc.perform(
+                        post(LOGIN_URL)
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(loginReq)))
                 .andExpectAll(
                         status().isOk(),
                         content().contentType(MediaType.APPLICATION_JSON),

--- a/teacher-module/teacher-application/build.gradle
+++ b/teacher-module/teacher-application/build.gradle
@@ -10,6 +10,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }

--- a/wronganswernote-module/wronganswernote-application/build.gradle
+++ b/wronganswernote-module/wronganswernote-application/build.gradle
@@ -10,6 +10,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
<!-- #{이슈 번호} -->
- #5 

### 내용
<!-- what! -->
- [x] memberController에 대한 `WebMvcTest` 작성
- [x] Service 계층에 `@Transactional` 선언

### 핵심 구현 방법
<!-- how! -->
- Controller 계층만 타겟으로 테스트를 하기 때문에 service 계층의 함수를 mocking 해줘야 함

### 전달 사항
<!-- 팀원과 함께 논의하고 싶은 내용 -->
- AsciiDoc 플러그인
  - 미리 화면을 볼 수 있도록 도와줌 
<img width="1012" alt="Untitled" src="https://github.com/oh-dab/server-api/assets/48800281/e1ca1d42-c948-4844-a202-52e60c9205dd">

<img width="1493" alt="image" src="https://github.com/oh-dab/server-api/assets/48800281/1615dc2d-65a6-4028-bafb-581c3cf9e579">

- `./gradlew build` 오류
  - 하위 모듈에 대한 자바 버전을 설정하지 않아서 발생한 문제 
<img width="1766" alt="image" src="https://github.com/oh-dab/server-api/assets/48800281/54ff0846-f96f-48dc-a43d-0318644b37a0">
