### PR TITLE
[Feat/#8] 학생별 오답노트 조회 controller 단위 테스트 & 구현

### DIFF
--- a/src/docs/asciidoc/ohdab.adoc
+++ b/src/docs/asciidoc/ohdab.adoc
@@ -26,3 +26,15 @@ include::{snippets}/members/login/http-request.adoc[]
 ==== Response
 
 include::{snippets}/members/login/http-response.adoc[]
+
+== WrongAnswerNote
+
+=== 학생별 오답노트 조회
+
+==== Request
+
+include::{snippets}/wrong_answer_note/getNoteInfoByStudent/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/wrong_answer_note/getNoteInfoByStudent/http-response.adoc[]

--- a/src/test/java/com/ohdab/webmvc/wronganswernote/WrongAnswerNoteControllerTest.java
+++ b/src/test/java/com/ohdab/webmvc/wronganswernote/WrongAnswerNoteControllerTest.java
@@ -1,0 +1,68 @@
+package com.ohdab.webmvc.wronganswernote;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ohdab.WrongAnswerNoteController;
+import com.ohdab.dto.NoteInfoByStudentDto;
+import com.ohdab.port.in.GetNoteInfoUsecase;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureRestDocs
+@WebMvcTest(controllers = WrongAnswerNoteController.class)
+class WrongAnswerNoteControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private GetNoteInfoUsecase getNoteInfoUsecase;
+
+    @Test
+    @WithMockUser
+    void 학생별_오답노트_조회() throws Exception {
+        // given
+        final String GET_NOTE_INFO_BY_STUDENT_URL = "/notes/workbooks/1/students/2";
+        List<NoteInfoByStudentDto> noteInfoByStudentDtoList = new ArrayList<>();
+        noteInfoByStudentDtoList.add(
+                NoteInfoByStudentDto.builder().wrongNumber(1).wrongCount(3).build());
+        noteInfoByStudentDtoList.add(
+                NoteInfoByStudentDto.builder().wrongNumber(2).wrongCount(1).build());
+
+        // when
+        when(getNoteInfoUsecase.getNoteInfoByStudent(anyLong(), anyLong()))
+                .thenReturn(noteInfoByStudentDtoList);
+
+        // then
+        mockMvc.perform(
+                        get(GET_NOTE_INFO_BY_STUDENT_URL)
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("$[0].wrongNumber")
+                                .value(noteInfoByStudentDtoList.get(0).getWrongNumber()),
+                        jsonPath("$[0].wrongCount")
+                                .value(noteInfoByStudentDtoList.get(0).getWrongCount()),
+                        jsonPath("$[1].wrongNumber")
+                                .value(noteInfoByStudentDtoList.get(1).getWrongNumber()),
+                        jsonPath("$[1].wrongCount")
+                                .value(noteInfoByStudentDtoList.get(1).getWrongCount()))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/ohdab/webmvc/wronganswernote/WrongAnswerNoteControllerTest.java
+++ b/src/test/java/com/ohdab/webmvc/wronganswernote/WrongAnswerNoteControllerTest.java
@@ -39,7 +39,8 @@ class WrongAnswerNoteControllerTest {
     @WithMockUser
     void 학생별_오답노트_조회() throws Exception {
         // given
-        final String GET_NOTE_INFO_BY_STUDENT_URL = "/notes/workbooks/1/students/2";
+        final String GET_NOTE_INFO_BY_STUDENT_URL =
+                "/notes/workbooks/{workbook-id}/students/{student-id}";
         List<NoteInfoByStudentDto> noteInfoByStudentDtoList = new ArrayList<>();
         noteInfoByStudentDtoList.add(
                 NoteInfoByStudentDto.builder().wrongNumber(1).wrongCount(3).build());
@@ -52,7 +53,7 @@ class WrongAnswerNoteControllerTest {
 
         // then
         mockMvc.perform(
-                        get(GET_NOTE_INFO_BY_STUDENT_URL)
+                        get(GET_NOTE_INFO_BY_STUDENT_URL, 1, 2)
                                 .with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpectAll(

--- a/src/test/java/com/ohdab/webmvc/wronganswernote/WrongAnswerNoteControllerTest.java
+++ b/src/test/java/com/ohdab/webmvc/wronganswernote/WrongAnswerNoteControllerTest.java
@@ -2,6 +2,8 @@ package com.ohdab.webmvc.wronganswernote;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -19,6 +21,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -63,6 +66,12 @@ class WrongAnswerNoteControllerTest {
                                 .value(noteInfoByStudentDtoList.get(1).getWrongNumber()),
                         jsonPath("$[1].wrongCount")
                                 .value(noteInfoByStudentDtoList.get(1).getWrongCount()))
-                .andDo(print());
+                .andDo(print())
+                .andDo(createDocument("wrong_answer_note/getNoteInfoByStudent"));
+    }
+
+    private RestDocumentationResultHandler createDocument(String identifier) {
+        return document(
+                identifier, preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint()));
     }
 }

--- a/wronganswernote-module/wronganswernote-application/src/main/java/com/ohdab/WrongAnswerNoteService.java
+++ b/wronganswernote-module/wronganswernote-application/src/main/java/com/ohdab/WrongAnswerNoteService.java
@@ -1,0 +1,17 @@
+package com.ohdab;
+
+import com.ohdab.dto.NoteInfoByStudentDto;
+import com.ohdab.port.in.GetNoteInfoUsecase;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WrongAnswerNoteService implements GetNoteInfoUsecase {
+
+    @Override
+    public List<NoteInfoByStudentDto> getNoteInfoByStudent(Long workbookId, Long studentId) {
+        return null;
+    }
+}

--- a/wronganswernote-module/wronganswernote-application/src/main/java/com/ohdab/dto/NoteInfoByStudentDto.java
+++ b/wronganswernote-module/wronganswernote-application/src/main/java/com/ohdab/dto/NoteInfoByStudentDto.java
@@ -1,0 +1,12 @@
+package com.ohdab.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NoteInfoByStudentDto {
+
+    private int wrongNumber;
+    private int wrongCount;
+}

--- a/wronganswernote-module/wronganswernote-application/src/main/java/com/ohdab/port/in/GetNoteInfoUsecase.java
+++ b/wronganswernote-module/wronganswernote-application/src/main/java/com/ohdab/port/in/GetNoteInfoUsecase.java
@@ -1,0 +1,9 @@
+package com.ohdab.port.in;
+
+import com.ohdab.dto.NoteInfoByStudentDto;
+import java.util.List;
+
+public interface GetNoteInfoUsecase {
+
+    List<NoteInfoByStudentDto> getNoteInfoByStudent(Long workbookId, Long studentId);
+}

--- a/wronganswernote-module/wronganswernote-web-adapter/src/main/java/com/ohdab/WrongAnswerNoteController.java
+++ b/wronganswernote-module/wronganswernote-web-adapter/src/main/java/com/ohdab/WrongAnswerNoteController.java
@@ -1,0 +1,32 @@
+package com.ohdab;
+
+import com.ohdab.dto.NoteInfoByStudentDto;
+import com.ohdab.mapper.WrongAnswerNoteMapper;
+import com.ohdab.port.in.GetNoteInfoUsecase;
+import com.ohdab.response.NoteInfoByStudentRes;
+import java.util.List;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notes")
+public class WrongAnswerNoteController {
+
+    private final GetNoteInfoUsecase getNoteInfoUsecase;
+
+    @GetMapping("/workbooks/{workbook-id}/students/{student-id}")
+    public ResponseEntity<List<NoteInfoByStudentRes>> getNoteInfoByStudent(
+            @Valid @PathVariable(name = "workbook-id") Long workbookId,
+            @PathVariable(name = "student-id") Long studentId) {
+        List<NoteInfoByStudentDto> noteInfoByStudentDtoList =
+                getNoteInfoUsecase.getNoteInfoByStudent(workbookId, studentId);
+        return ResponseEntity.ok(
+                WrongAnswerNoteMapper.toNoteInfoByStudentRes(noteInfoByStudentDtoList));
+    }
+}

--- a/wronganswernote-module/wronganswernote-web-adapter/src/main/java/com/ohdab/mapper/WrongAnswerNoteMapper.java
+++ b/wronganswernote-module/wronganswernote-web-adapter/src/main/java/com/ohdab/mapper/WrongAnswerNoteMapper.java
@@ -1,0 +1,24 @@
+package com.ohdab.mapper;
+
+import com.ohdab.dto.NoteInfoByStudentDto;
+import com.ohdab.response.NoteInfoByStudentRes;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WrongAnswerNoteMapper {
+
+    public static List<NoteInfoByStudentRes> toNoteInfoByStudentRes(
+            List<NoteInfoByStudentDto> noteInfoByStudentDtoList) {
+        return noteInfoByStudentDtoList.stream()
+                .map(
+                        dto ->
+                                NoteInfoByStudentRes.builder()
+                                        .wrongNumber(dto.getWrongNumber())
+                                        .wrongCount(dto.getWrongCount())
+                                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/wronganswernote-module/wronganswernote-web-adapter/src/main/java/com/ohdab/response/NoteInfoByStudentRes.java
+++ b/wronganswernote-module/wronganswernote-web-adapter/src/main/java/com/ohdab/response/NoteInfoByStudentRes.java
@@ -1,0 +1,12 @@
+package com.ohdab.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NoteInfoByStudentRes {
+
+    private int wrongNumber;
+    private int wrongCount;
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
<!-- #{이슈 번호} -->
- #8 

### 내용
<!-- what! -->
- [x] controller 단위 테스트
- [x] controller 구현
- [x] Res, DTO, Mapper 클래스 구현  

### 핵심 구현 방법
<!-- how! -->
- 없음

### 전달 사항
<!-- 팀원과 함께 논의하고 싶은 내용 -->
- `학생별 오답 조회`,  `N번 이상 틀린 문제 조회` 기능에서 DTO는 문제 번호, 틀린 횟수를 제공하면 되므로 DTO 클래스명을 추상적으로 결정함
  - `NoteInfoByStudentDto`
- `WrongAnswerNote~~` 와 같이 메서드, 객체 이름을 지정하고 싶은데 너무 길고 의미가 제대로 파악되지 않는 느낌이 들어서 간소화함
  - 더 나은 이름이 있으면 추천 부탁  