### PR TITLE
[Fix/#119] mistakenote 생성자 빌더 NPE 해결

### DIFF
--- a/src/main/java/com/ohdab/mistakenote/domain/MistakeNote.java
+++ b/src/main/java/com/ohdab/mistakenote/domain/MistakeNote.java
@@ -44,13 +44,12 @@ public class MistakeNote extends BaseEntity {
             WorkbookId workbookId, StudentId studentId, Map<Integer, Integer> mistakeRecords) {
         this.workbookId = workbookId;
         this.studentId = studentId;
-        this.mistakeRecords = mistakeRecords;
+        setMistakeRecords(mistakeRecords);
     }
 
-    @Builder
-    public MistakeNote(WorkbookId workbookId, StudentId studentId) {
-        this.workbookId = workbookId;
-        this.studentId = studentId;
+    private void setMistakeRecords(Map<Integer, Integer> mistakeRecords) {
+        if (mistakeRecords == null) mistakeRecords = new HashMap<>();
+        this.mistakeRecords = mistakeRecords;
     }
 
     public void addMistakeNumbers(

--- a/src/test/java/com/ohdab/mistakenote/repository/MistakeNoteRepositoryTest.java
+++ b/src/test/java/com/ohdab/mistakenote/repository/MistakeNoteRepositoryTest.java
@@ -50,9 +50,10 @@ class MistakeNoteRepositoryTest {
         // then
         assertThat(result.getWorkbookId().getId()).isEqualTo(workbookId.getId());
         assertThat(result.getStudentId().getId()).isEqualTo(studentId.getId());
-        assertThat(result.getMistakeRecords()).containsEntry(1, 2);
-        assertThat(result.getMistakeRecords()).containsEntry(2, 4);
-        assertThat(result.getMistakeRecords()).containsEntry(4, 1);
+        assertThat(result.getMistakeRecords())
+                .containsEntry(1, 2)
+                .containsEntry(2, 4)
+                .containsEntry(4, 1);
     }
 
     @DisplayName("변경감지를 활용하여 틀린 문제 번호마다 틀린 횟수를 저장한다.")
@@ -112,8 +113,7 @@ class MistakeNoteRepositoryTest {
         MistakeNote mistakeNote =
                 MistakeNote.builder()
                         .studentId(new StudentId(1L))
-                        .workbookId(new WorkbookId(1L))
-                        .mistakeRecords(new HashMap<>())
+                        .workbookId(new WorkbookId(2L))
                         .build();
 
         // when


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
<!-- #{이슈 번호} -->
- #119 

### 내용
<!-- what! -->
- [x] 생성자 오버로딩 후 빌더 어노테이션 태깅시 생성자 인식 실패 오류 해결

### 핵심 구현 방법
<!-- how! -->
- 오답기록 널값 체크  
<img width="916" alt="image" src="https://github.com/oh-dab/server-api/assets/48800281/15e0c0c1-417a-4377-82ef-bb1291b53a79">


### 전달 사항
<!-- 팀원과 함께 논의하고 싶은 내용 -->
- 없음